### PR TITLE
fixes for invoice note

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -510,21 +510,6 @@ function jsPDFInvoiceTemplate(props) {
     doc.text(docWidth - 10, currentHeight, param.invoice.total.col3 + "  " + param.invoice.total.col2, "right");
   }
 
-  // Note 
-  if (param.invoice.note) {
-    currentHeight += pdfConfig.lineHeight;
-    doc.setFont(undefined, 'bold');
-    doc.text(10, currentHeight, 'Note:');
-
-    doc.setFont(undefined, 'normal');
-    const noteData = splitTextAndGetHeight(param.invoice.note, (doc.getPageWidth() - 40))
-
-    doc.text(22, currentHeight, noteData.text);
-
-    // doc.text(item.text, 11, currentHeight + 4)
-    currentHeight += pdfConfig.lineHeight + noteData.height;
-  }
-
   // Amount Due
   doc.setFont(undefined, 'normal');
 
@@ -592,6 +577,23 @@ function jsPDFInvoiceTemplate(props) {
         currentHeight = 10;
       }
     }
+  }
+
+
+  // Note 
+  if (param.invoice.note) {
+    currentHeight += pdfConfig.lineHeight;
+    doc.setFont(undefined, 'bold');
+    doc.text(10, currentHeight, 'Note:');
+
+    doc.setFont(undefined, 'normal');
+    doc.setFontSize(pdfConfig.fieldTextSize);
+    const noteData = splitTextAndGetHeight(param.invoice.note, (doc.getPageWidth() - 40))
+    doc.setFontSize(pdfConfig.fieldTextSize);
+
+    doc.text(22, currentHeight, noteData.text);
+
+    currentHeight += pdfConfig.lineHeight + noteData.height;
   }
 
   var addInvoiceDesc = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -448,20 +448,7 @@ function jsPDFInvoiceTemplate(props) {
   doc.setFontSize(10);
   currentHeight += pdfConfig.lineHeight;
 
-  // Note 
-  if (param.invoice.note) {
-    currentHeight += pdfConfig.lineHeight;
-    doc.setFont(undefined, 'bold');
-    doc.text(10, currentHeight, 'Note:');
 
-    doc.setFont(undefined, 'normal');
-    const noteData = splitTextAndGetHeight(param.invoice.note, (doc.getPageWidth() - 40))
-
-    doc.text(22, currentHeight, noteData.text);
-
-    // doc.text(item.text, 11, currentHeight + 4)
-    currentHeight += pdfConfig.lineHeight + noteData.height;
-  }
 
   //line breaker before invoce total
   if (
@@ -521,6 +508,21 @@ function jsPDFInvoiceTemplate(props) {
     doc.setFont(undefined, 'bold');
     doc.text(docWidth - 50, currentHeight, param.invoice.total.col1, "right")
     doc.text(docWidth - 10, currentHeight, param.invoice.total.col3 + "  " + param.invoice.total.col2, "right");
+  }
+
+  // Note 
+  if (param.invoice.note) {
+    currentHeight += pdfConfig.lineHeight;
+    doc.setFont(undefined, 'bold');
+    doc.text(10, currentHeight, 'Note:');
+
+    doc.setFont(undefined, 'normal');
+    const noteData = splitTextAndGetHeight(param.invoice.note, (doc.getPageWidth() - 40))
+
+    doc.text(22, currentHeight, noteData.text);
+
+    // doc.text(item.text, 11, currentHeight + 4)
+    currentHeight += pdfConfig.lineHeight + noteData.height;
   }
 
   // Amount Due

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ export { OutputType, jsPDF };
  *       invDescLabel?: string,
  *       invDesc?: string,
  *       creditNoteLabel?: string,
+ *       note?: string,
  *       row1?: {
  *           col1?: string,
  *           col2?: string,
@@ -131,6 +132,7 @@ function jsPDFInvoiceTemplate(props) {
       invDescLabel: props.invoice?.invDescLabel || "",
       invDesc: props.invoice?.invDesc || "",
       creditNoteLabel: props.invoice?.creditNoteLabel || "",
+      note: props.invoice?.note || "",
       row1: {
         col1: props.invoice?.row1?.col1 || "",
         col2: props.invoice?.row1?.col2 || "",
@@ -445,6 +447,21 @@ function jsPDFInvoiceTemplate(props) {
   doc.setTextColor(colorBlack);
   doc.setFontSize(10);
   currentHeight += pdfConfig.lineHeight;
+
+  // Note 
+  if (param.invoice.note) {
+    currentHeight += pdfConfig.lineHeight;
+    doc.setFont(undefined, 'bold');
+    doc.text(10, currentHeight, 'Note:');
+
+    doc.setFont(undefined, 'normal');
+    const noteData = splitTextAndGetHeight(param.invoice.note, (doc.getPageWidth() - 40))
+
+    doc.text(22, currentHeight, noteData.text);
+
+    // doc.text(item.text, 11, currentHeight + 4)
+    currentHeight += pdfConfig.lineHeight + noteData.height;
+  }
 
   //line breaker before invoce total
   if (


### PR DESCRIPTION
Added invoice Export PDF
https://www.notion.so/peakflo/Invoice-PDF-should-show-invoice-notes-field-above-bottomNote-602c25e00fbc4325ab7038272d449491